### PR TITLE
Fixed restartTimer function

### DIFF
--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -310,7 +310,7 @@ Module.register('MMM-Carousel', {
     },
 
     restartTimer: function() {
-        if (this.transitionTimer > 0) {
+        if (this.config.transitionInterval > 0) {
             // Restart the timer
             clearInterval(this.transitionTimer);
             this.transitionTimer = setInterval(this.manualTransition, this.config.transitionInterval);

--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -310,7 +310,7 @@ Module.register('MMM-Carousel', {
     },
 
     restartTimer: function() {
-        if (this.config.transitionTimer > 0) {
+        if (this.transitionTimer > 0) {
             // Restart the timer
             clearInterval(this.transitionTimer);
             this.transitionTimer = setInterval(this.manualTransition, this.config.transitionInterval);


### PR DESCRIPTION
Simple bug fix- manual transitions were not resetting the timer. The 'restartTimer' function's condition was referencing "this.config.transitionTimer" which doesn't exist, I corrected it to "this.transitionTimer".