### PR TITLE
Fix transitionTimeout and going back to homeSlide after interval

### DIFF
--- a/MMM-Carousel.js
+++ b/MMM-Carousel.js
@@ -468,7 +468,7 @@ Module.register("MMM-Carousel", {
     }
   },
 
-  transitionTimeoutCallback: () => {
+  transitionTimeoutCallback: function() {
     let goToIndex = -1;
     let goToSlide;
     if (typeof this.config.homeSlide === "number") {
@@ -478,7 +478,7 @@ Module.register("MMM-Carousel", {
     } else {
       goToIndex = 0;
     }
-    this.moduleTransition(goToIndex, undefined, goToSlide);
+    this.manualTransition(goToIndex, undefined, goToSlide);
     this.restartTimer();
   },
 


### PR DESCRIPTION
Finally figured it out. It seems that you accidentally called moduleTransition instead of manualTransition.

Fixing the declaration of the `transitionTimeoutCallback` function and making the function call `this.manualTransition` instead of `this.moduleTransition` fixes the issues.

Resolves: https://github.com/shbatm/MMM-Carousel/issues/64