### PR TITLE
Clarify Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ There are three modes available:
 Run these commands at the root of your MagicMirror² to install.
 
 ```shell
-cd modules
+cd ~/MagicMirror/modules
 git clone https://github.com/shbatm/MMM-Carousel
 ```
 


### PR DESCRIPTION
Clarifying install instructions so they will work even if the user is not already in the `~/MagicMirror` directory.